### PR TITLE
feat: handle hexadecimal write and read

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -46,16 +46,20 @@ class Connection {
   send (content, opts) {
     if (this.state !== Connection.states().OPEN) {
       return Promise.reject(new Error('instance not in state OPEN'))
-    } else if (typeof content !== 'string') {
-      return Promise.reject(new Error('first argument must be a string'))
+    } else if (typeof content !== 'string' && !Buffer.isBuffer(content)) {
+      return Promise.reject(
+        new Error('first argument must be a string or a Buffer')
+      )
     }
     opts = opts || {}
     const terminator = opts.terminator || ''
     const timeoutInit = opts.timeoutInit || 100
     const timeoutRolling = opts.timeoutRolling || 10
+    const fixedRespBytesLength = opts.fixedRespBytesLength || -1
 
     this.state = Connection.states().INUSE
     let chunks = ''
+    const bytes = []
     let timer
 
     return new Promise((resolve, reject) => {
@@ -65,11 +69,15 @@ class Connection {
           timer = null
         }
         chunks = chunks.concat(data)
+        bytes.push(data.toString('hex').toUpperCase())
         if (terminator) {
           const ix = chunks.indexOf(terminator)
-          if (ix > 0 && ix === chunks.length + 1) {
+          if (
+            bytes.length >= fixedRespBytesLength ||
+            (ix > 0 && ix === chunks.length + 1)
+          ) {
             this.state = Connection.states().OPEN
-            resolve(chunks)
+            resolve(fixedRespBytesLength > 0 ? bytes.join('') : chunks)
           } else if (ix > 0 && ix !== chunks.length + 1) {
             this.state = Connection.states().ERROR
             reject(new Error('Terminator detected in the middle of answer. Check your options'))
@@ -77,7 +85,7 @@ class Connection {
           }
         }
         timer = setTimeout(() => {
-          resolve(chunks)
+          resolve(fixedRespBytesLength > 0 ? bytes.join('') : chunks)
         }, timeoutRolling)
       })
 
@@ -86,7 +94,7 @@ class Connection {
           reject(new Error(err))
         }
         timer = setTimeout(() => {
-          resolve(chunks)
+          resolve(fixedRespBytesLength > 0 ? bytes.join('') : chunks)
         }, timeoutInit)
       })
     })


### PR DESCRIPTION
In order to send hexadecimal input/output on serial port, this PR aim to :
- allow to write a Buffer type (for exemple receiving `Buffer.from("0614000400341101005E", "hex")` as content)
- handle fixed response length (bytes), adding `fixedRespBytesLength` to optin

for record it allows me to control a Viewsonic PX701HD projector ([RS-232 Protocol](https://www.viewsonicglobal.com/public/products_download/user_guide/Projector/PX701-4K_PX728-4K_PX748-4K/PX701-4k_PX748-4K_PX728-4K_%20RS232_table.pdf?pass))